### PR TITLE
PyCon 2017 Tutorial

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tutorials/2017-05-18-PyCon"]
+	path = tutorials/2017-05-18-PyCon
+	url = git@github.com:UnataInc/PyCon2017


### PR DESCRIPTION
I've added our PyCon2017 repository as a submodule in a new folder called "tutorials".
The repo contains:
* an IPython notebook, 'tutorial.ipynb', with all the content from the tutorial,
* another submodule, 'slideSources', pointing to a repo with the sources of the slides -- look for the raw content in `content.md`,
* a README.md with a link to the rendered slides that run in the browser.
* a link to the YouTube video, i.e. https://youtu.be/fR5Wvb86-IU